### PR TITLE
ARM: fix incorrect variable names

### DIFF
--- a/sha256-arm.c
+++ b/sha256-arm.c
@@ -61,8 +61,8 @@ void sha256_process_arm(uint32_t state[8], const uint8_t data[], uint32_t length
     while (length >= 64)
     {
         /* Save state */
-        ABEF_SAVE = STATE0;
-        CDGH_SAVE = STATE1;
+        ABCD_SAVE = STATE0;
+        EFGH_SAVE = STATE1;
 
         /* Load message */
         MSG0 = vld1q_u32((const uint32_t *)(data +  0));
@@ -198,8 +198,8 @@ void sha256_process_arm(uint32_t state[8], const uint8_t data[], uint32_t length
         STATE1 = vsha256h2q_u32(STATE1, TMP2, TMP1);
 
         /* Combine state */
-        STATE0 = vaddq_u32(STATE0, ABEF_SAVE);
-        STATE1 = vaddq_u32(STATE1, CDGH_SAVE);
+        STATE0 = vaddq_u32(STATE0, ABCD_SAVE);
+        STATE1 = vaddq_u32(STATE1, EFGH_SAVE);
 
         data += 64;
         length -= 64;


### PR DESCRIPTION
The ARM SHA256 functions take the state variables in simple alphabetic order, ABCD and EFGH.  Documented [here](https://developer.arm.com/architectures/instruction-sets/intrinsics/#f:@navigationhierarchiesinstructiongroup=[Cryptography,SHA256]).

The state is ordered and use correctly only the names are wrong.  So no calculations are changed.