### PR TITLE
sha256-arm: fix ABEF_SAVE/CDGH_SAVE var names

### DIFF
--- a/sha256-arm.c
+++ b/sha256-arm.c
@@ -50,7 +50,7 @@ static const uint32_t K[] =
 /*  state, and the caller is responsible for padding the final block.        */
 void sha256_process_arm(uint32_t state[8], const uint8_t data[], uint32_t length)
 {
-    uint32x4_t STATE0, STATE1, ABEF_SAVE, CDGH_SAVE;
+    uint32x4_t STATE0, STATE1, ABCD_SAVE, EFGH_SAVE;
     uint32x4_t MSG0, MSG1, MSG2, MSG3;
     uint32x4_t TMP0, TMP1, TMP2;
 


### PR DESCRIPTION
PR https://github.com/noloader/SHA-Intrinsics/pull/14 renamed `ABEF_SAVE`/`CDGH_SAVE` to `ABCD_SAVE`/`EFGH_SAVE` but missed the declaration.

As noted in the original commit of #14: ARM keeps state in natural order `[A,B,C,D]` and `[E,F,G,H]` unlike x86 SHA-NI which uses `[A,B,E,F]` and `[C,D,G,H]`. [Doc](https://developer.arm.com/architectures/instruction-sets/intrinsics/#f:@navigationhierarchiesinstructiongroup=[Cryptography,SHA256])

